### PR TITLE
TASK #73 - Turn JWT endpoint auth to middleware

### DIFF
--- a/endpoints/example/ex1.go
+++ b/endpoints/example/ex1.go
@@ -3,6 +3,7 @@ package example
 import (
 	"fmt"
 	"net/http"
+	"gopherfit/internal/middleware"
 )
 
 func GetServeMux() *http.ServeMux {
@@ -15,14 +16,15 @@ func GetServeMux() *http.ServeMux {
 }
 
 func handleHelloWorld(w http.ResponseWriter, r *http.Request) {
-	name := r.URL.Query().Get("name")
+	name := r.Context().Value(middleware.CtxUsernameKey)
+	id := r.Context().Value(middleware.CtxUserIDKey)
 	switch name {
 	case "":
 		http.Error(w, "must say your name", http.StatusBadRequest)
 	case "none":
 		w.Write([]byte("Hello stranger from /example/hello_world"))
 	default:
-		fmt.Fprintf(w, "Hello %s from /example/hello_world", name)
+		fmt.Fprintf(w, "Hello %s with id %d from /example/hello_world", name, id)
 	}
 }
 

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -43,7 +43,7 @@ func createToken(u User) (string, error) {
 * @return username string, our username
 * @return error, nil if no error
 */
-func verifyToken(tokenString string) (int, string, error) {
+func VerifyToken(tokenString string) (int, string, error) {
 	claims := &Claims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		return secretKey, nil

--- a/internal/middleware/jwt-middleware.go
+++ b/internal/middleware/jwt-middleware.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"context"
+	// "fmt"
+	"net/http"
+
+	"gopherfit/internal/auth"
+)
+
+/*
+* Middleware wrapper for our endpoints
+* @param Handler for our endpoint with type http.ServeMux or http.Handler
+*/
+func JWTMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokenString := r.Header.Get("Authorization")
+			if tokenString == "" {
+				http.Error(w, "Requires JWT Token", http.StatusUnauthorized)
+				return
+			}
+
+			// Retrieve the token string
+			tokenString = tokenString[len("Bearer "):]
+			id, username, err := auth.VerifyToken(tokenString)
+			if err != nil {
+				http.Error(w, "Invalid JWT Token", http.StatusUnauthorized)
+				return
+			}
+			// Create context to pass userID and username to our next handler
+			ctx := context.WithValue(r.Context(), CtxUserIDKey, id)
+			ctx = context.WithValue(ctx, CtxUsernameKey, username)
+
+			// You can retrieve id and username from the context by:
+				// import "gopherfit/internal/middleware"
+				// id := r.Context().Value(CtxUserIDKey)
+				// username := r.Context().Value(CtxUsernameKey)
+			// Check internal/middleware/models.go for any context keys
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+    	})
+}

--- a/internal/middleware/models.go
+++ b/internal/middleware/models.go
@@ -1,0 +1,12 @@
+package middleware
+
+import (
+
+)
+
+type contextKey string
+
+const (
+	CtxUserIDKey contextKey = "userID"
+	CtxUsernameKey contextKey = "username"
+)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"gopherfit/internal/workouts"
 	// "gopherfit/internal/social"
 	"gopherfit/internal/db"
+	"gopherfit/internal/middleware"
 )
 
 func main() {
@@ -25,14 +26,14 @@ func main() {
 
 	// the baseMux will mainly be used like this
 	baseMux.Handle("/practice/", practice.GetServeMux())
-	baseMux.Handle("/example/", example.GetServeMux())
+	baseMux.Handle("/example/", middleware.JWTMiddleware(example.GetServeMux()))
 
 	authHandler := auth.NewHandler(conn)
 	baseMux.Handle("/auth/", authHandler.RegisterRoutes())
 
 	nutritionHandler := nutrition.NewHandler(conn)
 	workoutsHandler := workouts.NewHandler(conn)
-	
+
 	baseMux.Handle("/nutrition/", nutritionHandler.RegisterRoutes())
 	baseMux.Handle("/workouts/", workoutsHandler.RegisterRoutes())
 


### PR DESCRIPTION
Created middleware to wrap around endpoints to allow us to verify tokens on protected endpoints.

See /example/hello_world endpoint for an example.

When JWTMiddleware() is wrapped around an endpoint, it will verify the token and parse the userID and username. This is then passed into the next handler using Context. If the token is invalid, it will send back an 401 unauthorized. 

To get the JWT token, you should register a user or login